### PR TITLE
Include `/api/status` endpoint (openshiftio/openshift.io#1783)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,21 @@ GLIDE_BIN := $(shell command -v $(GLIDE_BIN_NAME) 2> /dev/null)
 # This pattern excludes some folders from the coverage calculation (see grep -v)
 ALL_PKGS_EXCLUDE_PATTERN = 'vendor\|app\|tool\/cli\|design\|client\|test'
 
+
+COMMIT=$(shell git rev-parse HEAD)
+GITUNTRACKEDCHANGES := $(shell git status --porcelain --untracked-files=no)
+ifneq ($(GITUNTRACKEDCHANGES),)
+COMMIT := $(COMMIT)-dirty
+endif
+BUILD_TIME=`date -u '+%Y-%m-%dT%H:%M:%SZ'`
+
+PACKAGE_NAME := github.com/fabric8-services/fabric8-toggles-service
+
 # For the global "clean" target all targets in this variable will be executed
 CLEAN_TARGETS =
+
+# Pass in build time variables to main
+LDFLAGS=-ldflags "-X ${PACKAGE_NAME}/controller.Commit=${COMMIT} -X ${PACKAGE_NAME}/controller.BuildTime=${BUILD_TIME}"
 
 $(GOAGEN_BIN): $(VENDOR_DIR)
 	cd $(VENDOR_DIR)/github.com/goadesign/goa/goagen && go build -v
@@ -131,7 +144,7 @@ regenerate: clean-generated generate
 .PHONY: build
 ## Build fabric8-toggles-service.
 build: deps format-go-code generate
-	go build -ldflags="$(LDFLAGS)" -o bin/$(BINARY)
+	go build -v $(LDFLAGS) -o bin/$(BINARY)
 
 .PHONY: run
 ## Run fabric8-toggles-service.

--- a/controller/status.go
+++ b/controller/status.go
@@ -1,0 +1,49 @@
+package controller
+
+import (
+	"time"
+
+	"github.com/fabric8-services/fabric8-toggles-service/app"
+	"github.com/goadesign/goa"
+)
+
+var (
+	// Commit current build commit set by build script
+	Commit = "0"
+	// BuildTime set by build script in ISO 8601 (UTC) format: YYYY-MM-DDThh:mm:ssTZD (see https://www.w3.org/TR/NOTE-datetime for details)
+	BuildTime = "0"
+	// StartTime in ISO 8601 (UTC) format
+	StartTime = time.Now().UTC().Format("2006-01-02T15:04:05Z")
+)
+
+type StatusConfiguration interface {
+	IsDeveloperModeEnabled() bool
+}
+
+// StatusController implements the status resource.
+type StatusController struct {
+	*goa.Controller
+	config StatusConfiguration
+}
+
+// NewStatusController creates a status controller.
+func NewStatusController(service *goa.Service, config StatusConfiguration) *StatusController {
+	return &StatusController{
+		Controller: service.NewController("StatusController"),
+		config:     config,
+	}
+}
+
+// Show runs the show action.
+func (c *StatusController) Show(ctx *app.ShowStatusContext) error {
+	res := &app.Status{
+		Commit:    Commit,
+		BuildTime: BuildTime,
+		StartTime: StartTime,
+	}
+	devMode := c.config.IsDeveloperModeEnabled()
+	if devMode {
+		res.DevMode = &devMode
+	}
+	return ctx.OK(res)
+}

--- a/design/status.go
+++ b/design/status.go
@@ -1,0 +1,39 @@
+package design
+
+import (
+	d "github.com/goadesign/goa/design"
+	a "github.com/goadesign/goa/design/apidsl"
+)
+
+// AuthStatus defines the status of the current running Auth instance
+var status = a.MediaType("application/vnd.status+json", func() {
+	a.Description("The status of the current running instance")
+	a.Attributes(func() {
+		a.Attribute("commit", d.String, "Commit SHA this build is based on")
+		a.Attribute("buildTime", d.String, "The time when built")
+		a.Attribute("startTime", d.String, "The time when started")
+		a.Attribute("devMode", d.Boolean, "'True' if the Developer Mode is enabled")
+		a.Required("commit", "buildTime", "startTime")
+	})
+	a.View("default", func() {
+		a.Attribute("commit")
+		a.Attribute("buildTime")
+		a.Attribute("startTime")
+		a.Attribute("devMode")
+	})
+})
+
+var _ = a.Resource("status", func() {
+
+	a.DefaultMedia(status)
+	a.BasePath("/status")
+
+	a.Action("show", func() {
+		a.Routing(
+			a.GET(""),
+		)
+		a.Description("Show the status of the current running instance")
+		a.Response(d.OK)
+		a.Response(d.ServiceUnavailable, status)
+	})
+})

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	witmiddleware "github.com/fabric8-services/fabric8-wit/goamiddleware"
 	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/goadesign/goa"
-	"github.com/goadesign/goa/logging/logrus"
+	goalogrus "github.com/goadesign/goa/logging/logrus"
 	"github.com/goadesign/goa/middleware"
 	"github.com/goadesign/goa/middleware/gzip"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
@@ -73,6 +73,15 @@ func main() {
 	// Mount "feature" controller
 	featureCtrl := controller.NewFeatureController(service, toggleClient)
 	app.MountFeatureController(service, featureCtrl)
+
+	// Mount "status" controller
+	statusCtrl := controller.NewStatusController(service, config)
+	app.MountStatusController(service, statusCtrl)
+
+	log.Logger().Infoln("Git Commit SHA: ", controller.Commit)
+	log.Logger().Infoln("UTC Build Time: ", controller.BuildTime)
+	log.Logger().Infoln("UTC Start Time: ", controller.StartTime)
+	log.Logger().Infoln("Dev mode:       ", config.IsDeveloperModeEnabled())
 
 	http.Handle("/favicon.ico", http.NotFoundHandler())
 	http.Handle("/", service.Mux)


### PR DESCRIPTION
Also, use variables filled with `LDFLAGS` at build time

Fixes openshiftio/openshift.io#1783

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>