### PR TITLE
fix basepath for API

### DIFF
--- a/design/api.go
+++ b/design/api.go
@@ -11,7 +11,7 @@ var _ = a.API("feature", func() {
 	a.Version("1.0")
 	a.Host("openshift.io")
 	a.Scheme("http")
-	a.BasePath("/")
+	a.BasePath("/api")
 	a.Consumes("application/json")
 	a.Produces("application/json")
 

--- a/design/features.go
+++ b/design/features.go
@@ -48,7 +48,7 @@ var featureAttributes = a.Type("FeatureAttributes", func() {
 })
 
 var _ = a.Resource("features", func() {
-	a.BasePath("/api/features")
+	a.BasePath("/features")
 
 	a.Action("show", func() {
 		a.Security("jwt")

--- a/main.go
+++ b/main.go
@@ -79,8 +79,8 @@ func main() {
 	log.Logger().Infoln("UTC Start Time: ", controller.StartTime)
 	log.Logger().Infoln("Dev mode:       ", config.IsDeveloperModeEnabled())
 
+	http.Handle("/api/", service.Mux)
 	http.Handle("/favicon.ico", http.NotFoundHandler())
-	http.Handle("/", service.Mux)
 
 	// Start http
 	if err := http.ListenAndServe(config.GetHTTPAddress(), nil); err != nil {


### PR DESCRIPTION
this enables the `/api/status` endpoint, needed by the Openshift probes

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>