### PR TITLE
Toggle-Service respond with 500 on expired token. Should be 401 (OSIO#2471)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -74,7 +74,7 @@
     "rest",
     "token"
   ]
-  revision = "40219482fe0628ab9aa03eaa4484bc90b6da5216"
+  revision = "f49fbf645355af271893af5d54ac1abbcdaf378f"
 
 [[projects]]
   branch = "master"
@@ -341,6 +341,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "565f663566329da64e561b3d258e10e49bf2c2e31e647498fd93a77d0d0144b3"
+  inputs-digest = "9d3f657dff97c3c61b9abbf6c827bde7637c1b5c5ed2a522655105baae3e0d01"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,7 +71,7 @@ ignored = [
 
 [[constraint]]
   name = "github.com/fabric8-services/fabric8-auth"
-  revision = "40219482fe0628ab9aa03eaa4484bc90b6da5216"
+  revision = "f49fbf645355af271893af5d54ac1abbcdaf378f"
 
 [[constraint]]
   name = "github.com/gojuno/minimock"

--- a/controller/features.go
+++ b/controller/features.go
@@ -86,7 +86,7 @@ func (c *FeaturesController) List(ctx *app.ListFeaturesContext) error {
 	if jwtToken != nil {
 		_, err := c.tokenParser.Parse(ctx, jwtToken.Raw)
 		if err != nil {
-			log.Error(ctx, map[string]interface{}{"error": err.Error()}, "Error while checking the JWT")
+			log.Error(ctx, map[string]interface{}{"error": err.Error()}, "error while parsing the user's token")
 			return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("invalid token"))
 		}
 		if user, err = c.getUserProfile(ctx); err != nil {
@@ -107,7 +107,7 @@ func (c *FeaturesController) Show(ctx *app.ShowFeaturesContext) error {
 	if jwtToken != nil {
 		_, err := c.tokenParser.Parse(ctx, jwtToken.Raw)
 		if err != nil {
-			log.Error(ctx, map[string]interface{}{"error": err.Error()}, "Error while checking the JWT")
+			log.Error(ctx, map[string]interface{}{"error": err.Error()}, "error while parsing the user's token")
 			return jsonapi.JSONErrorResponse(ctx, errors.NewUnauthorizedError("invalid token"))
 		}
 		if user, err = c.getUserProfile(ctx); err != nil {

--- a/test/data/token/auth_get_keys.yaml
+++ b/test/data/token/auth_get_keys.yaml
@@ -28,11 +28,10 @@ interactions:
         {
           "alg": "RS256",
           "e": "AQAB",
-          "kid": "billythekid",
+          "kid": "test_key",
           "kty": "RSA",
           "n": "DpfS9jJGDXFUqjw5QAKm8M5ciqBDelRrmby5VPaPi7P8tvyS3YBKyLBfAAVOkvoFwSBcz94yuGh2q8tP8LIM8QLbixeaB5OSUC-z9Oq-bRhUlJEtZ1fqaHzwGC0ru6rrd8rEZRij1iaVPsX16Mm12RNpACmjyhr_PEcLeLQA9KVpjTNTUX3n1BhK0VUIrxKSfdxs4MX_5I3WjGPf_-3r2wacxap9OWUVwbuEPfrXAan89cj-fxTWxU57etkR5wdbAkXmSW0u7rLtfKoek9iuTxCn4WjWjdZ8Rxobs_YllW97fk_7FhYG-bsRGxuqKHlpIUnPwLeEqXBJA4RW220",
           "use": "sig"
-
         }
       ]
     }'


### PR DESCRIPTION
Updated dependency to `fabric8-auth` whose goa middleware impl fixes the response
status when the request token is invalid or expired

Also, updated the tests

Fixes openshiftio/openshift.io#2471

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>