### PR TITLE
Set resource limits on Container level

### DIFF
--- a/openshift/app.yml
+++ b/openshift/app.yml
@@ -57,7 +57,9 @@ objects:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
-          resources: {}
+          resources:
+            limits:
+              memory: 1Gi            
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         dnsPolicy: ClusterFirst


### PR DESCRIPTION
Restrict how much memory the container can consume.

Limit to avoid it overtaking the cluster if the process were to go rogue.

Related to openshiftio/openshift.io#2685