### PR TITLE
Default level for user consent should be Production only (OSIO#2692)

### DIFF
--- a/controller/features.go
+++ b/controller/features.go
@@ -186,13 +186,18 @@ func (c *FeaturesController) convertFeatureData(ctx context.Context, feature *un
 	}
 	enabledForUser := c.togglesClient.IsFeatureEnabled(ctx, *feature, userLevel)
 	log.Debug(ctx, map[string]interface{}{"internal_user": internalUser}, "converting feature")
+	enablementLevel := featuretoggles.ComputeEnablementLevel(ctx, feature, internalUser)
+	var enablement *string
+	if enablementLevel != featuretoggles.UnknownLevel { // skip value in response if enablement level is "unknown"
+		enablement = &enablementLevel
+	}
 	return &app.Feature{
 		ID:   feature.Name,
 		Type: "features",
 		Attributes: &app.FeatureAttributes{
 			Description:     feature.Description,
 			Enabled:         feature.Enabled,
-			EnablementLevel: featuretoggles.ComputeEnablementLevel(ctx, feature, internalUser),
+			EnablementLevel: enablement,
 			UserEnabled:     enabledForUser,
 		},
 	}

--- a/controller/features.go
+++ b/controller/features.go
@@ -172,7 +172,7 @@ func (c *FeaturesController) convertFeature(ctx context.Context, feature *unleas
 
 func (c *FeaturesController) convertFeatureData(ctx context.Context, feature *unleashapi.Feature, user *client.User) *app.Feature {
 	internalUser := false
-	userLevel := featuretoggles.ReleasedLevel
+	userLevel := featuretoggles.ReleasedLevel // default level of features that the user can use
 	if user != nil {
 		userEmail := user.Data.Attributes.Email
 		userEmailVerified := user.Data.Attributes.EmailVerified
@@ -180,7 +180,9 @@ func (c *FeaturesController) convertFeatureData(ctx context.Context, feature *un
 		if userEmailVerified != nil && *userEmailVerified && userEmail != nil && strings.HasSuffix(*userEmail, "@redhat.com") {
 			internalUser = true
 		}
-		if user.Data.Attributes.FeatureLevel != nil {
+		// do not override the userLevel if the value is nil or empty. Any other value is accepted,
+		// but will be converted (with a fallback to `unknown` if needed)
+		if user.Data.Attributes.FeatureLevel != nil && *user.Data.Attributes.FeatureLevel != "" {
 			userLevel = *user.Data.Attributes.FeatureLevel
 		}
 	}

--- a/controller/features_test.go
+++ b/controller/features_test.go
@@ -285,6 +285,28 @@ func TestShowFeatures(t *testing.T) {
 				assert.Equal(t, expectedFeatureData, appFeature.Data)
 			})
 
+			t.Run("user with empty level", func(t *testing.T) {
+				// given
+				ctx, err := createValidContext("../test/private_key.pem", "user_empty_level", time.Now().Add(1*time.Hour))
+				require.NoError(t, err)
+				// when
+				_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, releasedFeature.Name)
+				// then
+				require.NotNil(t, appFeature)
+				enablementLevel := featuretoggles.ReleasedLevel
+				expectedFeatureData := &app.Feature{
+					ID:   releasedFeature.Name,
+					Type: "features",
+					Attributes: &app.FeatureAttributes{
+						Description:     releasedFeature.Description,
+						Enabled:         true,
+						UserEnabled:     true,
+						EnablementLevel: &enablementLevel,
+					},
+				}
+				assert.Equal(t, expectedFeatureData, appFeature.Data)
+			})
+
 			t.Run("user with enough level", func(t *testing.T) {
 
 				t.Run("experimental level", func(t *testing.T) {

--- a/featuretoggles/enablebylevel_strategy.go
+++ b/featuretoggles/enablebylevel_strategy.go
@@ -23,9 +23,9 @@ func (s *EnableByLevelStrategy) Name() string {
 
 // IsEnabled returns `true` if the given context is compatible with the settings configured on the Unleash server
 func (s *EnableByLevelStrategy) IsEnabled(settings map[string]interface{}, ctx *unleashcontext.Context) bool {
-	log.Debug(nil, map[string]interface{}{"settings_group_id": settings[LevelParameter], "properties_group_id": ctx.Properties[LevelParameter]}, "checking if feature is enabled for user, based on his/her group...")
+	log.Debug(nil, map[string]interface{}{"settings_level": settings[LevelParameter], "context_level": ctx.Properties[LevelParameter]}, "checking if feature is enabled for user, based on his/her group...")
 	userLevel := ctx.Properties[LevelParameter]
-	featureLevel := toFeatureLevel(settings[LevelParameter].(string), userLevel == InternalLevel)
+	featureLevel := toFeatureLevel(settings[LevelParameter].(string))
 	return featureLevel.IsEnabled(userLevel)
 
 }

--- a/featuretoggles/enablebylevel_strategy.go
+++ b/featuretoggles/enablebylevel_strategy.go
@@ -25,7 +25,7 @@ func (s *EnableByLevelStrategy) Name() string {
 func (s *EnableByLevelStrategy) IsEnabled(settings map[string]interface{}, ctx *unleashcontext.Context) bool {
 	log.Debug(nil, map[string]interface{}{"settings_level": settings[LevelParameter], "context_level": ctx.Properties[LevelParameter]}, "checking if feature is enabled for user, based on his/her group...")
 	userLevel := ctx.Properties[LevelParameter]
-	featureLevel := toFeatureLevel(settings[LevelParameter].(string))
+	featureLevel := toFeatureLevel(settings[LevelParameter].(string), unknown)
 	return featureLevel.IsEnabled(userLevel)
 
 }

--- a/featuretoggles/enablement_level.go
+++ b/featuretoggles/enablement_level.go
@@ -45,7 +45,7 @@ func ComputeEnablementLevel(ctx context.Context, feature *unleashapi.Feature, in
 		if s.Name == EnableByLevelStrategyName {
 			if level, found := s.Parameters[LevelParameter]; found {
 				if levelStr, ok := level.(string); ok {
-					featureLevel := toFeatureLevel(levelStr)
+					featureLevel := toFeatureLevel(levelStr, unknown)
 					// log.Debug(ctx, map[string]interface{}{"feature_name": feature.Name, "enablement_level": enablementLevel, "strategy_group": featureLevel}, "computing enablement level")
 					// beta > experimental > internal (if user is a RH internal)
 					if featureLevel > enablementLevel {
@@ -65,7 +65,7 @@ func ComputeEnablementLevel(ctx context.Context, feature *unleashapi.Feature, in
 	return result
 }
 
-func toFeatureLevel(level string) (result FeatureLevel) {
+func toFeatureLevel(level string, defaultLevel FeatureLevel) (result FeatureLevel) {
 	defer log.Debug(nil,
 		map[string]interface{}{
 			"feature_level": result,
@@ -81,7 +81,7 @@ func toFeatureLevel(level string) (result FeatureLevel) {
 	case ReleasedLevel:
 		return released
 	default:
-		return unknown
+		return defaultLevel
 	}
 }
 
@@ -102,6 +102,6 @@ func fromFeatureLevel(level FeatureLevel) string {
 
 // IsEnabled verifies if this feature is enabled for the given userLevel
 func (featureLevel FeatureLevel) IsEnabled(userLevel string) bool {
-	userLevelInt := toFeatureLevel(userLevel)
+	userLevelInt := toFeatureLevel(userLevel, released)
 	return featureLevel >= userLevelInt
 }

--- a/featuretoggles/enablement_level.go
+++ b/featuretoggles/enablement_level.go
@@ -12,17 +12,15 @@ import (
 type FeatureLevel int
 
 const (
-	unknown FeatureLevel = iota
-	internal
+	internal FeatureLevel = iota
 	experimental
 	beta
 	released
+	unknown
 )
 
 // FeatureLevelStr custom type for feature level constants as strings
 const (
-	// UnknownLevel the unknown level for feature toggles (only used if the backend config does not match any level here)
-	UnknownLevel = "unknown"
 	// InternalLevel the Internal level for feature toggles
 	InternalLevel = "internal"
 	// ExperimentalLevel the Experimental level for feature toggles
@@ -31,18 +29,23 @@ const (
 	BetaLevel = "beta"
 	// ReleasedLevel the Released level for feature toggles
 	ReleasedLevel = "released"
+	// UnknownLevel the unknown level for feature toggles (only used if the backend config does not match any level here)
+	UnknownLevel = "unknown"
 )
 
 // ComputeEnablementLevel computes the enablement level required to be able to use the given feature (if it is enabled at all)
-func ComputeEnablementLevel(ctx context.Context, feature *unleashapi.Feature, internalUser bool) *string {
-	enablementLevel := unknown
+func ComputeEnablementLevel(ctx context.Context, feature *unleashapi.Feature, internalUser bool) string {
+	if feature.Enabled == false || len(feature.Strategies) == 0 {
+		return UnknownLevel
+	}
+	enablementLevel := internal
 	// iterate on feature's strategies
 	for _, s := range feature.Strategies {
 		// log.Debug(ctx, map[string]interface{}{"feature_name": feature.Name, "enablement_level": enablementLevel, "strategy_name": s.Name}, "computing enablement level")
 		if s.Name == EnableByLevelStrategyName {
 			if level, found := s.Parameters[LevelParameter]; found {
 				if levelStr, ok := level.(string); ok {
-					featureLevel := toFeatureLevel(levelStr, internalUser)
+					featureLevel := toFeatureLevel(levelStr)
 					// log.Debug(ctx, map[string]interface{}{"feature_name": feature.Name, "enablement_level": enablementLevel, "strategy_group": featureLevel}, "computing enablement level")
 					// beta > experimental > internal (if user is a RH internal)
 					if featureLevel > enablementLevel {
@@ -52,17 +55,25 @@ func ComputeEnablementLevel(ctx context.Context, feature *unleashapi.Feature, in
 			}
 		}
 	}
-	log.Debug(ctx, map[string]interface{}{"internal_user": internalUser, "feature_name": feature.Name, "enablement_level": enablementLevel}, "computed enablement level")
-	return fromFeatureLevel(enablementLevel)
+	// need to re-adjust the level if the user is "external" and the enablement level is "internal"
+	// i.e., the feature is internal-only, so the external user is not allowed to use it
+	if !internalUser && enablementLevel == internal {
+		enablementLevel = unknown
+	}
+	result := fromFeatureLevel(enablementLevel)
+	log.Debug(ctx, map[string]interface{}{"internal_user": internalUser, "feature_name": feature.Name, "enablement_level": result}, "computed enablement level")
+	return result
 }
 
-func toFeatureLevel(level string, internalUser bool) FeatureLevel {
+func toFeatureLevel(level string) (result FeatureLevel) {
+	defer log.Debug(nil,
+		map[string]interface{}{
+			"feature_level": result,
+			"level":         level},
+		"converted feature level")
 	switch strings.ToLower(level) {
 	case InternalLevel:
-		if internalUser {
-			return internal
-		}
-		return unknown
+		return internal
 	case ExperimentalLevel:
 		return experimental
 	case BetaLevel:
@@ -74,25 +85,23 @@ func toFeatureLevel(level string, internalUser bool) FeatureLevel {
 	}
 }
 
-func fromFeatureLevel(level FeatureLevel) *string {
-	var result string
+func fromFeatureLevel(level FeatureLevel) string {
 	switch level {
 	case internal:
-		result = InternalLevel
+		return InternalLevel
 	case experimental:
-		result = ExperimentalLevel
+		return ExperimentalLevel
 	case beta:
-		result = BetaLevel
+		return BetaLevel
 	case released:
-		result = ReleasedLevel
+		return ReleasedLevel
 	default:
-		return nil
+		return UnknownLevel
 	}
-
-	return &result
 }
 
+// IsEnabled verifies if this feature is enabled for the given userLevel
 func (featureLevel FeatureLevel) IsEnabled(userLevel string) bool {
-	userLevelInt := toFeatureLevel(userLevel, userLevel == InternalLevel)
+	userLevelInt := toFeatureLevel(userLevel)
 	return featureLevel >= userLevelInt
 }

--- a/featuretoggles/enablement_level_whitebox_test.go
+++ b/featuretoggles/enablement_level_whitebox_test.go
@@ -1,6 +1,7 @@
 package featuretoggles
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -8,111 +9,80 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFeatureLevelIsEnabled(t *testing.T) {
-	t.Run("isEnabled for cumulative values", func(t *testing.T) {
-		// given
-		type FeatureLevelTest struct {
-			featureLevel   FeatureLevel
-			userLevel      string
-			expectedResult bool
-		}
-		testData := []FeatureLevelTest{
-			{internal, InternalLevel, true},
-			{internal, ExperimentalLevel, false},
-			{internal, BetaLevel, false},
-			{internal, ReleasedLevel, false},
-			{experimental, InternalLevel, true},
-			{experimental, ExperimentalLevel, true},
-			{experimental, BetaLevel, false},
-			{experimental, ReleasedLevel, false},
-			{beta, InternalLevel, true},
-			{beta, ExperimentalLevel, true},
-			{beta, BetaLevel, true},
-			{beta, ReleasedLevel, false},
-			{released, InternalLevel, true},
-			{released, ExperimentalLevel, true},
-			{released, BetaLevel, true},
-			{released, ReleasedLevel, true},
-		}
-		for _, test := range testData {
+func TestFeatureIsEnabled(t *testing.T) {
+	// given
+	type FeatureLevelTest struct {
+		featureLevel   FeatureLevel
+		userLevel      string
+		expectedResult bool
+	}
+	testData := []FeatureLevelTest{
+		{internal, InternalLevel, true},
+		{internal, ExperimentalLevel, false},
+		{internal, BetaLevel, false},
+		{internal, ReleasedLevel, false},
+		{experimental, InternalLevel, true},
+		{experimental, ExperimentalLevel, true},
+		{experimental, BetaLevel, false},
+		{experimental, ReleasedLevel, false},
+		{beta, InternalLevel, true},
+		{beta, ExperimentalLevel, true},
+		{beta, BetaLevel, true},
+		{beta, ReleasedLevel, false},
+		{released, InternalLevel, true},
+		{released, ExperimentalLevel, true},
+		{released, BetaLevel, true},
+		{released, ReleasedLevel, true},
+		{internal, "", false},     // new user with no level specified
+		{experimental, "", false}, // new user with no level specified
+		{beta, "", false},         // new user with no level specified
+	}
+	for _, test := range testData {
+		t.Run(fmt.Sprintf("%s vs %v -> %t", fromFeatureLevel(test.featureLevel), test.userLevel, test.expectedResult), func(t *testing.T) {
 			assert.Equal(t, test.expectedResult, test.featureLevel.IsEnabled(test.userLevel))
-		}
-	})
+		})
+	}
 }
 func TestFeatureLevelConversion(t *testing.T) {
 
 	t.Run("convert from feature level type", func(t *testing.T) {
 		// given
-		internalLevel := InternalLevel
-		experimentalLevel := ExperimentalLevel
-		betaLevel := BetaLevel
-		releasedLevel := ReleasedLevel
-		dataSet := map[FeatureLevel]*string{
-			internal:     &internalLevel,
-			experimental: &experimentalLevel,
-			beta:         &betaLevel,
-			released:     &releasedLevel,
-			unknown:      nil,
+		dataSet := map[FeatureLevel]string{
+			internal:     InternalLevel,
+			experimental: ExperimentalLevel,
+			beta:         BetaLevel,
+			released:     ReleasedLevel,
+			unknown:      UnknownLevel,
 		}
 		// iterate over the data set
 		for inputFeatureLevel, expectedValue := range dataSet {
-			if expectedValue != nil {
-				t.Run(*expectedValue, func(t *testing.T) {
-					// when
-					result := fromFeatureLevel(inputFeatureLevel)
-					// then
-					require.NotNil(t, result)
-					assert.Equal(t, *expectedValue, *result)
-				})
-			} else {
-				t.Run("unknown value", func(t *testing.T) {
-					// when
-					result := fromFeatureLevel(inputFeatureLevel)
-					// then
-					require.Nil(t, result)
-				})
-			}
+			t.Run(expectedValue, func(t *testing.T) {
+				// when
+				result := fromFeatureLevel(inputFeatureLevel)
+				// then
+				require.NotNil(t, result)
+				assert.Equal(t, expectedValue, result)
+			})
 		}
 	})
 
 	t.Run("convert to feature level type", func(t *testing.T) {
-		t.Run("with internal user", func(t *testing.T) {
-			// given
-			internalUserDataSet := map[string]FeatureLevel{
-				InternalLevel:     internal,
-				ExperimentalLevel: experimental,
-				BetaLevel:         beta,
-				ReleasedLevel:     released,
-				UnknownLevel:      unknown,
-			}
-			// iterate over the data set
-			for inputValue, expectedFeatureLevel := range internalUserDataSet {
-				t.Run(inputValue, func(t *testing.T) {
-					// when
-					result := toFeatureLevel(inputValue, true)
-					// then
-					assert.Equal(t, expectedFeatureLevel, result)
-				})
-			}
-		})
-		t.Run("with external user", func(t *testing.T) {
-			// given
-			externalUserDataSet := map[string]FeatureLevel{
-				InternalLevel:     unknown,
-				ExperimentalLevel: experimental,
-				BetaLevel:         beta,
-				ReleasedLevel:     released,
-				UnknownLevel:      unknown,
-			}
-			// iterate over the data set
-			for inputValue, expectedFeatureLevel := range externalUserDataSet {
-				t.Run(inputValue, func(t *testing.T) {
-					// when
-					result := toFeatureLevel(inputValue, false)
-					// then
-					assert.Equal(t, expectedFeatureLevel, result)
-				})
-			}
-		})
+		// given
+		dataSet := map[string]FeatureLevel{
+			InternalLevel:     internal,
+			ExperimentalLevel: experimental,
+			BetaLevel:         beta,
+			ReleasedLevel:     released,
+			UnknownLevel:      unknown,
+		}
+		// iterate over the data set
+		for inputValue, expectedFeatureLevel := range dataSet {
+			t.Run(inputValue, func(t *testing.T) {
+				// when
+				result := toFeatureLevel(inputValue)
+				// then
+				assert.Equal(t, expectedFeatureLevel, result)
+			})
+		}
 	})
 }

--- a/featuretoggles/enablement_level_whitebox_test.go
+++ b/featuretoggles/enablement_level_whitebox_test.go
@@ -33,9 +33,10 @@ func TestFeatureIsEnabled(t *testing.T) {
 		{released, ExperimentalLevel, true},
 		{released, BetaLevel, true},
 		{released, ReleasedLevel, true},
-		{internal, "", false},     // new user with no level specified
-		{experimental, "", false}, // new user with no level specified
-		{beta, "", false},         // new user with no level specified
+		{internal, "", false},     // new user with no level specified is considered as `released` and can not use a non-`released` feature
+		{experimental, "", false}, // new user with no level specified is considered as `released` and can not use a non-`released` feature
+		{beta, "", false},         // new user with no level specified is considered as `released` and can not use a non-`released` feature
+		{released, "", true},      // new user with no level specified is considered as `released` and can use a `released` feature
 	}
 	for _, test := range testData {
 		t.Run(fmt.Sprintf("%s vs %v -> %t", fromFeatureLevel(test.featureLevel), test.userLevel, test.expectedResult), func(t *testing.T) {
@@ -79,7 +80,7 @@ func TestFeatureLevelConversion(t *testing.T) {
 		for inputValue, expectedFeatureLevel := range dataSet {
 			t.Run(inputValue, func(t *testing.T) {
 				// when
-				result := toFeatureLevel(inputValue)
+				result := toFeatureLevel(inputValue, unknown)
 				// then
 				assert.Equal(t, expectedFeatureLevel, result)
 			})

--- a/test/data/controller/auth_get_user.yaml
+++ b/test/data/controller/auth_get_user.yaml
@@ -115,3 +115,26 @@ interactions:
         "type": "identities"
       }
     }'
+- request:
+    method: GET
+    url: http://auth/api/user
+    headers:
+      sub: ["user_empty_level"] # will be compared against the `sub` claim in the incoming request's token
+  response:
+    status: 200 OK
+    code: 200
+    body: '{
+      "data": {
+        "attributes": {
+          "bio": "",
+          "cluster": "https://api.starter-us-east-2.openshift.com",
+          "company": "Red Hat",
+          "email": "user@baz.com",
+          "fullName": "Jeff Baz",
+          "username": "baz",
+          "featureLevel": ""
+        },
+        "id": "22269698-dc27-4ec4-bfc8-290bad6000",
+        "type": "identities"
+      }
+    }'


### PR DESCRIPTION
Reorder the `FeatureLevel` constants, with `unknown` becoming the
highest value for the comparisons.
Refactor the `ComputeEnablementLevel` to put the logic of comparing
the internal/external level in it and set the default value when
the feature is disabled or has no strategy configured (or an invalid
value)
Refactor some functions to avoid returning pointers.
Include a test to verify the enablement level for a feature with
a misconfigured level and for a user with no consent.

Fixes openshiftio/openshift.io#2692

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>