### PR TITLE
Do not return a 404 response when the feature does not exist (OSIO#2785)

### DIFF
--- a/controller/features_test.go
+++ b/controller/features_test.go
@@ -378,14 +378,24 @@ func TestShowFeatures(t *testing.T) {
 		})
 	})
 
-	t.Run("fail", func(t *testing.T) {
-		t.Run("not found", func(t *testing.T) {
-			// given
-			ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
-			require.NoError(t, err)
-			// when/then
-			test.ShowFeaturesNotFound(t, ctx, svc, ctrl, "UnknownFeature")
-		})
+	t.Run("unknown feature", func(t *testing.T) {
+		// given
+		ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
+		require.NoError(t, err)
+		// when
+		_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, "UnknownFeature")
+		// then
+		require.NotNil(t, appFeature)
+		expectedFeatureData := &app.Feature{
+			ID:   "UnknownFeature",
+			Type: "features",
+			Attributes: &app.FeatureAttributes{
+				Description: "unknown feature",
+				Enabled:     false,
+				UserEnabled: false,
+			},
+		}
+		assert.Equal(t, expectedFeatureData, appFeature.Data)
 	})
 
 	t.Run("invalid", func(t *testing.T) {

--- a/design/features.go
+++ b/design/features.go
@@ -60,7 +60,6 @@ var _ = a.Resource("features", func() {
 		a.Response(d.OK, featureSingle)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
-		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 	})
 
@@ -75,7 +74,6 @@ var _ = a.Resource("features", func() {
 		a.Response(d.OK, featureList)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
-		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 	})
 })


### PR DESCRIPTION
Return an empty feature that is not enabled when the feature does not
exist in the toggle server

Fixes openshiftio/openshift.io#2785

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>