### PR TITLE
Build on RHEL

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,17 @@
+# -----------------------------------------------------------------
+# Docker file to copy the generated binary from the `out` directory
+# -----------------------------------------------------------------
+FROM prod.registry.devshift.net/osio-prod/base/pcp:latest
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+EXPOSE 8080
+ARG BINARY
+COPY ${BINARY} /usr/local/bin/fabric8-toggles-service
+
+ENV F8_USER_NAME=fabric8
+RUN useradd --no-create-home -s /bin/bash ${F8_USER_NAME}
+# From here onwards, any RUN, CMD, or ENTRYPOINT will be run under the following user
+USER ${F8_USER_NAME}
+
+ENTRYPOINT [ "fabric8-toggles-service" ]

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ login:
 	$(call check_defined, REGISTRY_PASSWORD, "You need to pass the registry password via REGISTRY_PASSWORD.")
 	docker login -u $(REGISTRY_USER) -p $(REGISTRY_PASSWORD) $(REGISTRY_URI)
 
-image: clean-artifacts build-linux login
+image: clean-artifacts build-linux
 	docker build -t $(REGISTRY_URL) \
 	  --build-arg BINARY=$(BUILD_DIR)/$(PROJECT_NAME) \
 	  -f $(DOCKERFILE) .

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,15 @@ PROJECT_NAME = fabric8-toggles-service
 REGISTRY_URI = push.registry.devshift.net
 REGISTRY_NS = fabric8-services
 REGISTRY_IMAGE = ${PROJECT_NAME}
-REGISTRY_URL = ${REGISTRY_URI}/${REGISTRY_NS}/${REGISTRY_IMAGE}
+
+ifeq ($(TARGET),rhel)
+	REGISTRY_URL := ${REGISTRY_URI}/osio-prod/${REGISTRY_NS}/${REGISTRY_IMAGE}
+	DOCKERFILE := Dockerfile.rhel
+else
+	REGISTRY_URL := ${REGISTRY_URI}/${REGISTRY_NS}/${REGISTRY_IMAGE}
+	DOCKERFILE := Dockerfile
+endif
+
 PACKAGE_NAME := github.com/fabric8-services/${PROJECT_NAME}
 SOURCE_DIR ?= .
 SOURCES := $(shell find $(SOURCE_DIR) -type d \( -name vendor -o -name .glide \) -prune -o -name '*.go' -print)
@@ -63,20 +71,22 @@ build: deps generate $(BUILD_DIR) # Builds the Linux binary for the container im
 build-linux: deps generate $(BUILD_DIR) # Builds the Linux binary for the container image into $BUILD_DIR
 	CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -v $(LDFLAGS) -o $(BUILD_DIR)/$(PROJECT_NAME)
 
-image: clean-artifacts build-linux
+login:
+	$(call check_defined, REGISTRY_USER, "You need to pass the registry user via REGISTRY_USER.")
+	$(call check_defined, REGISTRY_PASSWORD, "You need to pass the registry password via REGISTRY_PASSWORD.")
+	docker login -u $(REGISTRY_USER) -p $(REGISTRY_PASSWORD) $(REGISTRY_URI)
+
+image: clean-artifacts build-linux login
 	docker build -t $(REGISTRY_URL) \
 	  --build-arg BINARY=$(BUILD_DIR)/$(PROJECT_NAME) \
-	  -f Dockerfile .
+	  -f $(DOCKERFILE) .
 
 image-minishift: clean-artifacts build-linux
 	@eval $$(minishift docker-env) && docker build -t $(REGISTRY_URL) \
 	  --build-arg BINARY=$(BUILD_DIR)/$(PROJECT_NAME) \
-	  -f Dockerfile .
+	  -f $(DOCKERFILE) .
 
 push-openshift: image ## Pushes the container image to the OpenShift online registry
-	$(call check_defined, REGISTRY_USER, "You need to pass the registry user via REGISTRY_USER.")
-	$(call check_defined, REGISTRY_PASSWORD, "You need to pass the registry password via REGISTRY_PASSWORD.")
-	docker login -u $(REGISTRY_USER) -p $(REGISTRY_PASSWORD) $(REGISTRY_URI)
 	docker push $(REGISTRY_URL):latest
 	docker tag $(REGISTRY_URL):latest $(REGISTRY_URL):$(IMAGE_TAG)
 	docker push $(REGISTRY_URL):$(IMAGE_TAG)

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -16,7 +16,7 @@ function setup_build_environment() {
     [ -f inherit-env ] && . inherit-env
 
     # We need to disable selinux for now, XXX
-    /usr/sbin/setenforce 0
+    /usr/sbin/setenforce 0 || :
 
     yum -y install docker make golang git
     service docker start
@@ -35,7 +35,7 @@ function setup_golang() {
   # Show Go version
   go version
   # Setup GOPATH
-  mkdir $HOME/go $HOME/go/src $HOME/go/bin $HOME/go/pkg
+  mkdir -p  $HOME/go $HOME/go/src $HOME/go/bin $HOME/go/pkg
   export GOPATH=$HOME/go
   export PATH=$GOPATH/bin:$PATH
 }
@@ -59,11 +59,12 @@ setup_workspace
 
 cd $GOPATH/src/github.com/fabric8-services/fabric8-toggles-service
 echo "HEAD of repository `git rev-parse --short HEAD`"
+make login REGISTRY_USER=${DEVSHIFT_USERNAME} REGISTRY_PASSWORD=${DEVSHIFT_PASSWORD}
 make all
 
 bash <(curl -s https://codecov.io/bash) -f coverage.txt -t cbdff99f-9158-4128-8dec-ef6afb6d78ab
 
 if [[ "$JOB_NAME" = "devtools-fabric8-toggles-service-build-master" ]]; then
     TAG=$(echo ${GIT_COMMIT} | cut -c1-${DEVSHIFT_TAG_LEN})
-    make push-openshift REGISTRY_USER=${DEVSHIFT_USERNAME} REGISTRY_PASSWORD=${DEVSHIFT_PASSWORD} IMAGE_TAG=${TAG}
+    make push-openshift IMAGE_TAG=${TAG}
 fi

--- a/openshift/app.yml
+++ b/openshift/app.yml
@@ -31,7 +31,7 @@ objects:
               configMapKeyRef:
                 name: f8toggles-service
                 key: toggles.url
-          image: registry.devshift.net/fabric8-services/fabric8-toggles-service:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3
@@ -86,5 +86,7 @@ objects:
     type: ClusterIP
     sessionAffinity: null
 parameters:
+- name: IMAGE
+  value: registry.devshift.net/fabric8-services/fabric8-toggles-service
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

The cico environment will continue to build the CentOS based container and in a second step it will build and push a RHEL based container. As of now, the CentOS containers will be the ones being deployed to prod-preview and prod.

This PR will remain as a WIP until this PR is merged and validated:
https://github.com/fabric8-services/fabric8-auth/pull/432