### PR TITLE
Support for conditional requests on toggles-service endpoints (OSIO#3218)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ generate-goa: deps $(DESIGNS) $(GOAGEN_BIN) deps ## Generate GOA sources. Only n
 	$(GOAGEN_BIN) controller -d ${PACKAGE_NAME}/${DESIGN_DIR} -o controller/ --pkg controller --app-pkg app
 	$(GOAGEN_BIN) swagger -d ${PACKAGE_NAME}/${DESIGN_DIR}
 	$(GOAGEN_BIN) client -d github.com/fabric8-services/fabric8-auth/design --notool --pkg client -o auth
+	$(GOAGEN_BIN) gen -d ${PACKAGE_NAME}/${DESIGN_DIR} --pkg-path=${PACKAGE_NAME}/goasupport/conditional_request --out app
 
 $(MINIMOCK_BIN):
 	@echo "building the minimock binary..."

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -49,6 +49,7 @@ const (
 	varDeveloperModeEnabled           = "developer.mode.enabled"
 	varTogglesURL                     = "toggles.url"
 	varAuthURL                        = "auth.url"
+	varFeaturesCacheControl           = "features.cachecontrol"
 	varAPIServerInsecureSkipTLSVerify = "api.server.insecure.skip.tls.verify"
 	varLogLevel                       = "log.level"
 	varLogJSON                        = "log.json"
@@ -62,6 +63,11 @@ type Data struct {
 // GetAuthServiceURL returns the Auth Service URL
 func (c *Data) GetAuthServiceURL() string {
 	return c.v.GetString(varAuthURL)
+}
+
+// GetFeaturesCacheControl returns the `cache-control` response header value to use when returning features
+func (c *Data) GetFeaturesCacheControl() string {
+	return c.v.GetString(varFeaturesCacheControl)
 }
 
 // NewData creates a configuration reader object using a configurable configuration file path
@@ -115,6 +121,11 @@ func (c *Data) setConfigDefaults() {
 	//-----
 	c.v.SetDefault(varDeveloperModeEnabled, false)
 	c.v.SetDefault(varLogLevel, defaultLogLevel)
+
+	// ----
+	// Cache control
+	// ----
+	c.v.SetDefault(varFeaturesCacheControl, "private,max-age=120")
 
 }
 

--- a/controller/features_test.go
+++ b/controller/features_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	unleashapi "github.com/Unleash/unleash-client-go/api"
 	jwt "github.com/dgrijalva/jwt-go"
 	jwtrequest "github.com/dgrijalva/jwt-go/request"
 	"github.com/dnaeon/go-vcr/cassette"
@@ -29,99 +28,64 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var disabledFeature, singleStrategyFeature, multiStrategiesFeature, releasedFeature, devFeature, fooGroupFeature, foobarFeature unleashapi.Feature
+var disabledFeature, singleStrategyFeature, multiStrategiesFeature, releasedFeature, devFeature, fooGroupFeature, foobarFeature featuretoggles.UserFeature
 
 func init() {
 	// features
-	disabledFeature = unleashapi.Feature{
-		Name:        "foo.disabledFeature",
-		Description: "Disabled feature",
-		Enabled:     false,
-		Strategies:  []unleashapi.Strategy{},
+	disabledFeature = featuretoggles.UserFeature{
+		Name:            "foo.disabledFeature",
+		Description:     "Disabled feature",
+		Enabled:         false,
+		EnablementLevel: featuretoggles.UnknownLevel,
+		UserEnabled:     false,
 	}
 
-	singleStrategyFeature = unleashapi.Feature{
-		Name:        "foo.singleStrategyFeature",
-		Description: "Feature with single strategy",
-		Enabled:     true,
-		Strategies: []unleashapi.Strategy{
-			{
-				Name: featuretoggles.EnableByLevelStrategyName,
-				Parameters: map[string]interface{}{
-					featuretoggles.LevelParameter: featuretoggles.InternalLevel,
-				},
-			},
-		},
+	singleStrategyFeature = featuretoggles.UserFeature{
+		Name:            "foo.singleStrategyFeature",
+		Description:     "Feature with single strategy",
+		Enabled:         true,
+		EnablementLevel: featuretoggles.UnknownLevel,
+		UserEnabled:     false,
 	}
 
-	multiStrategiesFeature = unleashapi.Feature{
-		Name:        "foo.multiStrategiesFeature",
-		Description: "Feature with multiple strategies",
-		Enabled:     true,
-		Strategies: []unleashapi.Strategy{
-			{
-				Name: featuretoggles.EnableByLevelStrategyName,
-				Parameters: map[string]interface{}{
-					featuretoggles.LevelParameter: featuretoggles.InternalLevel,
-				},
-			},
-			{
-				Name: featuretoggles.EnableByLevelStrategyName,
-				Parameters: map[string]interface{}{
-					featuretoggles.LevelParameter: featuretoggles.ExperimentalLevel,
-				},
-			},
-			{
-				Name: featuretoggles.EnableByLevelStrategyName,
-				Parameters: map[string]interface{}{
-					featuretoggles.LevelParameter: featuretoggles.BetaLevel,
-				},
-			},
-		},
+	multiStrategiesFeature = featuretoggles.UserFeature{
+		Name:            "foo.multiStrategiesFeature",
+		Description:     "Feature with multiple strategies",
+		Enabled:         true,
+		EnablementLevel: featuretoggles.BetaLevel,
+		UserEnabled:     true,
 	}
 
-	releasedFeature = unleashapi.Feature{
-		Name:        "bar.releasedFeature",
-		Description: "Feature released",
-		Enabled:     true,
-		Strategies: []unleashapi.Strategy{
-			{
-				Name: featuretoggles.EnableByLevelStrategyName,
-				Parameters: map[string]interface{}{
-					featuretoggles.LevelParameter: featuretoggles.ReleasedLevel,
-				},
-			},
-		},
+	releasedFeature = featuretoggles.UserFeature{
+		Name:            "bar.releasedFeature",
+		Description:     "Feature released",
+		Enabled:         true,
+		EnablementLevel: featuretoggles.ReleasedLevel,
+		UserEnabled:     true,
 	}
 
-	devFeature = unleashapi.Feature{
-		Name:        "wip.devFeature",
-		Description: "WIP Feature",
-		Enabled:     true,
-		Strategies: []unleashapi.Strategy{
-			{
-				Name: featuretoggles.EnableByEmailsStrategyName,
-				Parameters: map[string]interface{}{
-					featuretoggles.EmailsParameter: []string{
-						"foo@foo.com",
-					},
-				},
-			},
-		},
+	devFeature = featuretoggles.UserFeature{
+		Name:            "wip.devFeature",
+		Description:     "WIP Feature",
+		Enabled:         true,
+		UserEnabled:     true,
+		EnablementLevel: featuretoggles.UnknownLevel,
 	}
 
-	fooGroupFeature = unleashapi.Feature{
-		Name:        "foo",
-		Description: "foo",
-		Enabled:     false,
-		Strategies:  []unleashapi.Strategy{},
+	fooGroupFeature = featuretoggles.UserFeature{
+		Name:            "foo",
+		Description:     "foo",
+		Enabled:         false,
+		UserEnabled:     false,
+		EnablementLevel: featuretoggles.UnknownLevel,
 	}
 
-	foobarFeature = unleashapi.Feature{
-		Name:        "foobar",
-		Description: "foo bar",
-		Enabled:     false,
-		Strategies:  []unleashapi.Strategy{},
+	foobarFeature = featuretoggles.UserFeature{
+		Name:            "foobar",
+		Description:     "foo bar",
+		Enabled:         false,
+		UserEnabled:     false,
+		EnablementLevel: featuretoggles.UnknownLevel,
 	}
 
 }
@@ -136,6 +100,10 @@ func (c *TestFeatureControllerConfig) GetAuthServiceURL() string {
 
 func (c *TestFeatureControllerConfig) GetTogglesURL() string {
 	return ""
+}
+
+func (c *TestFeatureControllerConfig) GetFeaturesCacheControl() string {
+	return "private,max-age=120"
 }
 
 func newFeaturesController(t *testing.T, tokenParser authtoken.Parser, httpClient *http.Client, client featuretoggles.Client) (*goa.Service, *controller.FeaturesController) {
@@ -153,58 +121,34 @@ func newFeaturesController(t *testing.T, tokenParser authtoken.Parser, httpClien
 
 func newClientMock(t *testing.T) *testfeaturetoggles.ClientMock {
 	mockClient := testfeaturetoggles.NewClientMock(t)
-	mockClient.GetFeatureFunc = func(ctx context.Context, name string) *unleashapi.Feature {
+	mockClient.GetFeatureFunc = func(ctx context.Context, name string, user *authclient.User) featuretoggles.UserFeature {
 		switch name {
 		case disabledFeature.Name:
-			return &disabledFeature
+			return disabledFeature
 		case singleStrategyFeature.Name:
-			return &singleStrategyFeature
+			return singleStrategyFeature
 		case multiStrategiesFeature.Name:
-			return &multiStrategiesFeature
+			return multiStrategiesFeature
 		case releasedFeature.Name:
-			return &releasedFeature
+			return releasedFeature
 		case devFeature.Name:
-			return &devFeature
+			return devFeature
 		default:
-			return nil
+			return featuretoggles.ZeroUserFeature
 		}
 	}
-	mockClient.IsFeatureEnabledFunc = func(ctx context.Context, feature unleashapi.Feature, user *authclient.User) (bool, string) {
-		log.Debug(ctx, map[string]interface{}{"user": user, "feature_name": feature.Name}, "checking if feature is enabled... (mock)")
-		if reflect.DeepEqual(feature, disabledFeature) {
-			return false, featuretoggles.UnknownLevel // disabled
-		}
-		if reflect.DeepEqual(feature, singleStrategyFeature) {
-			if user != nil && user.Data.Attributes.FeatureLevel != nil && *user.Data.Attributes.FeatureLevel == featuretoggles.InternalLevel {
-				return true, featuretoggles.InternalLevel // internal level
-			}
-			return false, featuretoggles.UnknownLevel // internal level
-		}
-		if reflect.DeepEqual(feature, multiStrategiesFeature) {
-			if user == nil {
-				return false, featuretoggles.BetaLevel
-			}
-			return true, featuretoggles.BetaLevel // assume user is beta or lower
-		}
-		if reflect.DeepEqual(feature, releasedFeature) {
-			return true, featuretoggles.ReleasedLevel
-		}
-		// if reflect.DeepEqual(feature, devFeature) {
-		// 	// check the email address of the user in the ctx, if available
-		// }
-		return false, featuretoggles.UnknownLevel
-	}
-	mockClient.GetFeaturesByNameFunc = func(ctx context.Context, names []string) []unleashapi.Feature {
+
+	mockClient.GetFeaturesByNameFunc = func(ctx context.Context, names []string, user *authclient.User) []featuretoggles.UserFeature {
 		if reflect.DeepEqual(names, []string{disabledFeature.Name, multiStrategiesFeature.Name}) {
-			return []unleashapi.Feature{disabledFeature, multiStrategiesFeature}
+			return []featuretoggles.UserFeature{disabledFeature, multiStrategiesFeature}
 		} else if reflect.DeepEqual(names, []string{releasedFeature.Name, disabledFeature.Name, multiStrategiesFeature.Name}) {
-			return []unleashapi.Feature{releasedFeature, disabledFeature, multiStrategiesFeature}
+			return []featuretoggles.UserFeature{releasedFeature, disabledFeature, multiStrategiesFeature}
 		}
 		return nil
 	}
-	mockClient.GetFeaturesByPatternFunc = func(ctx context.Context, pattern string) []unleashapi.Feature {
+	mockClient.GetFeaturesByPatternFunc = func(ctx context.Context, pattern string, user *authclient.User) []featuretoggles.UserFeature {
 		if pattern == "foo" {
-			return []unleashapi.Feature{
+			return []featuretoggles.UserFeature{
 				disabledFeature,
 				singleStrategyFeature,
 				multiStrategiesFeature,
@@ -212,11 +156,11 @@ func newClientMock(t *testing.T) *testfeaturetoggles.ClientMock {
 			}
 		}
 		if pattern == "bar" {
-			return []unleashapi.Feature{
+			return []featuretoggles.UserFeature{
 				releasedFeature,
 			}
 		}
-		return []unleashapi.Feature{}
+		return []featuretoggles.UserFeature{}
 	}
 	return mockClient
 }
@@ -246,13 +190,13 @@ func TestShowFeatures(t *testing.T) {
 			// when
 			ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
 			require.NoError(t, err)
-			_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, disabledFeature.Name)
+			_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, disabledFeature.Name, nil)
 			// then
 			require.NotNil(t, appFeature)
-			expectedFeatureData := &app.Feature{
+			expectedFeatureData := &app.UserFeature{
 				ID:   disabledFeature.Name,
 				Type: "features",
-				Attributes: &app.FeatureAttributes{
+				Attributes: &app.UserFeatureAttributes{
 					Description:     disabledFeature.Description,
 					Enabled:         false,
 					UserEnabled:     false,
@@ -266,13 +210,13 @@ func TestShowFeatures(t *testing.T) {
 			// when
 			ctx, err := createValidContext("../test/private_key.pem", "user_no_level", time.Now().Add(1*time.Hour))
 			require.NoError(t, err)
-			_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, singleStrategyFeature.Name)
+			_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, singleStrategyFeature.Name, nil)
 			// then
 			require.NotNil(t, appFeature)
-			expectedFeatureData := &app.Feature{
+			expectedFeatureData := &app.UserFeature{
 				ID:   singleStrategyFeature.Name,
 				Type: "features",
-				Attributes: &app.FeatureAttributes{
+				Attributes: &app.UserFeatureAttributes{
 					Description:     singleStrategyFeature.Description,
 					Enabled:         true,
 					UserEnabled:     false,
@@ -295,14 +239,14 @@ func TestShowFeatures(t *testing.T) {
 					ctx, err := createValidContext("../test/private_key.pem", "user_experimental_level", time.Now().Add(1*time.Hour))
 					require.NoError(t, err)
 					// when
-					_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, multiStrategiesFeature.Name)
+					_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, multiStrategiesFeature.Name, nil)
 					// then
 					require.NotNil(t, appFeature)
 					enablementLevel := featuretoggles.BetaLevel
-					expectedFeatureData := &app.Feature{
+					expectedFeatureData := &app.UserFeature{
 						ID:   multiStrategiesFeature.Name,
 						Type: "features",
-						Attributes: &app.FeatureAttributes{
+						Attributes: &app.UserFeatureAttributes{
 							Description:     multiStrategiesFeature.Description,
 							Enabled:         true,
 							UserEnabled:     true,
@@ -321,14 +265,14 @@ func TestShowFeatures(t *testing.T) {
 				ctx, err := createValidContext("../test/private_key.pem", "user_no_level", time.Now().Add(1*time.Hour))
 				require.NoError(t, err)
 				// when
-				_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, releasedFeature.Name)
+				_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, releasedFeature.Name, nil)
 				// then
 				require.NotNil(t, appFeature)
 				enablementLevel := featuretoggles.ReleasedLevel
-				expectedFeatureData := &app.Feature{
+				expectedFeatureData := &app.UserFeature{
 					ID:   releasedFeature.Name,
 					Type: "features",
-					Attributes: &app.FeatureAttributes{
+					Attributes: &app.UserFeatureAttributes{
 						Description:     releasedFeature.Description,
 						Enabled:         true,
 						UserEnabled:     true,
@@ -343,14 +287,14 @@ func TestShowFeatures(t *testing.T) {
 				ctx, err := createValidContext("../test/private_key.pem", "user_empty_level", time.Now().Add(1*time.Hour))
 				require.NoError(t, err)
 				// when
-				_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, releasedFeature.Name)
+				_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, releasedFeature.Name, nil)
 				// then
 				require.NotNil(t, appFeature)
 				enablementLevel := featuretoggles.ReleasedLevel
-				expectedFeatureData := &app.Feature{
+				expectedFeatureData := &app.UserFeature{
 					ID:   releasedFeature.Name,
 					Type: "features",
-					Attributes: &app.FeatureAttributes{
+					Attributes: &app.UserFeatureAttributes{
 						Description:     releasedFeature.Description,
 						Enabled:         true,
 						UserEnabled:     true,
@@ -367,14 +311,14 @@ func TestShowFeatures(t *testing.T) {
 					ctx, err := createValidContext("../test/private_key.pem", "user_experimental_level", time.Now().Add(1*time.Hour))
 					require.NoError(t, err)
 					// when
-					_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, releasedFeature.Name)
+					_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, releasedFeature.Name, nil)
 					// then
 					require.NotNil(t, appFeature)
 					enablementLevel := featuretoggles.ReleasedLevel
-					expectedFeatureData := &app.Feature{
+					expectedFeatureData := &app.UserFeature{
 						ID:   releasedFeature.Name,
 						Type: "features",
-						Attributes: &app.FeatureAttributes{
+						Attributes: &app.UserFeatureAttributes{
 							Description:     releasedFeature.Description,
 							Enabled:         true,
 							UserEnabled:     true,
@@ -389,14 +333,14 @@ func TestShowFeatures(t *testing.T) {
 					ctx, err := createValidContext("../test/private_key.pem", "user_released_level", time.Now().Add(1*time.Hour))
 					require.NoError(t, err)
 					// when
-					_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, releasedFeature.Name)
+					_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, releasedFeature.Name, nil)
 					// then
 					require.NotNil(t, appFeature)
 					enablementLevel := featuretoggles.ReleasedLevel
-					expectedFeatureData := &app.Feature{
+					expectedFeatureData := &app.UserFeature{
 						ID:   releasedFeature.Name,
 						Type: "features",
-						Attributes: &app.FeatureAttributes{
+						Attributes: &app.UserFeatureAttributes{
 							Description:     releasedFeature.Description,
 							Enabled:         true,
 							UserEnabled:     true,
@@ -410,18 +354,40 @@ func TestShowFeatures(t *testing.T) {
 		})
 	})
 
+	t.Run("no change", func(t *testing.T) {
+		// given
+		ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
+		require.NoError(t, err)
+		res, _ := test.ShowFeaturesOK(t, ctx, svc, ctrl, disabledFeature.Name, nil)
+		require.NotEmpty(t, res.Header()[app.ETag])
+		etag := res.Header()[app.ETag][0]
+		// when/then
+		test.ShowFeaturesNotModified(t, ctx, svc, ctrl, disabledFeature.Name, &etag)
+	})
+
+	t.Run("expired ETag", func(t *testing.T) {
+		// given
+		ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
+		require.NoError(t, err)
+		etag := "foo"
+		// when
+		_, features := test.ShowFeaturesOK(t, ctx, svc, ctrl, disabledFeature.Name, &etag)
+		//then
+		assert.NotEmpty(t, features)
+	})
+
 	t.Run("unknown feature", func(t *testing.T) {
 		// given
 		ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
 		require.NoError(t, err)
 		// when
-		_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, "UnknownFeature")
+		_, appFeature := test.ShowFeaturesOK(t, ctx, svc, ctrl, "UnknownFeature", nil)
 		// then
 		require.NotNil(t, appFeature)
-		expectedFeatureData := &app.Feature{
+		expectedFeatureData := &app.UserFeature{
 			ID:   "UnknownFeature",
 			Type: "features",
-			Attributes: &app.FeatureAttributes{
+			Attributes: &app.UserFeatureAttributes{
 				Description: "unknown feature",
 				Enabled:     false,
 				UserEnabled: false,
@@ -437,7 +403,7 @@ func TestShowFeatures(t *testing.T) {
 			ctx, err := createValidContext("../test/private_key2.pem", "user_beta_level", time.Now().Add(1*time.Hour))
 			require.NoError(t, err)
 			// when/then
-			test.ShowFeaturesUnauthorized(t, ctx, svc, ctrl, releasedFeature.Name)
+			test.ShowFeaturesUnauthorized(t, ctx, svc, ctrl, releasedFeature.Name, nil)
 		})
 
 		t.Run("expired token", func(t *testing.T) {
@@ -445,7 +411,7 @@ func TestShowFeatures(t *testing.T) {
 			ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(-1*time.Hour))
 			require.NoError(t, err)
 			// when/then
-			test.ShowFeaturesUnauthorized(t, ctx, svc, ctrl, releasedFeature.Name)
+			test.ShowFeaturesUnauthorized(t, ctx, svc, ctrl, releasedFeature.Name, nil)
 		})
 	})
 }
@@ -477,14 +443,14 @@ func TestListFeatures(t *testing.T) {
 			// when
 			ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
 			require.NoError(t, err)
-			_, featuresList := test.ListFeaturesOK(t, ctx, svc, ctrl, nil, []string{disabledFeature.Name, multiStrategiesFeature.Name})
+			_, featuresList := test.ListFeaturesOK(t, ctx, svc, ctrl, nil, []string{disabledFeature.Name, multiStrategiesFeature.Name}, nil)
 			// then
 			betaLevel := featuretoggles.BetaLevel
-			expectedData := []*app.Feature{
+			expectedData := []*app.UserFeature{
 				{
 					ID:   disabledFeature.Name,
 					Type: "features",
-					Attributes: &app.FeatureAttributes{
+					Attributes: &app.UserFeatureAttributes{
 						Description:     disabledFeature.Description,
 						Enabled:         false,
 						UserEnabled:     false,
@@ -494,7 +460,7 @@ func TestListFeatures(t *testing.T) {
 				{
 					ID:   multiStrategiesFeature.Name,
 					Type: "features",
-					Attributes: &app.FeatureAttributes{
+					Attributes: &app.UserFeatureAttributes{
 						Description:     multiStrategiesFeature.Description,
 						Enabled:         true,
 						UserEnabled:     true,
@@ -503,66 +469,40 @@ func TestListFeatures(t *testing.T) {
 				},
 			}
 			assert.Equal(t, expectedData, featuresList.Data)
+		})
+
+		t.Run("no change", func(t *testing.T) {
+			// given
+			ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
+			require.NoError(t, err)
+			res, _ := test.ListFeaturesOK(t, ctx, svc, ctrl, nil, []string{disabledFeature.Name, multiStrategiesFeature.Name}, nil)
+			require.NotEmpty(t, res.Header()[app.ETag])
+			etag := res.Header()[app.ETag][0]
+			// when/then
+			test.ListFeaturesNotModified(t, ctx, svc, ctrl, nil, []string{disabledFeature.Name, multiStrategiesFeature.Name}, &etag)
+		})
+
+		t.Run("expired ETag", func(t *testing.T) {
+			// given
+			ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
+			require.NoError(t, err)
+			etag := "foo"
+			// when
+			_, features := test.ListFeaturesOK(t, ctx, svc, ctrl, nil, []string{disabledFeature.Name, multiStrategiesFeature.Name}, &etag)
+			//then
+			assert.NotEmpty(t, features)
 		})
 
 		t.Run("no feature found", func(t *testing.T) {
 			// when
 			ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
 			require.NoError(t, err)
-			_, featuresList := test.ListFeaturesOK(t, ctx, svc, ctrl, nil, []string{"FeatureX", "FeatureY", "FeatureZ"})
+			_, featuresList := test.ListFeaturesOK(t, ctx, svc, ctrl, nil, []string{"FeatureX", "FeatureY", "FeatureZ"}, nil)
 			// then
-			expectedData := []*app.Feature{}
+			expectedData := []*app.UserFeature{}
 			assert.Equal(t, expectedData, featuresList.Data)
 		})
 
-		t.Run("no user provided", func(t *testing.T) {
-			// when
-			_, featuresList := test.ListFeaturesOK(t, context.Background(), svc, ctrl, nil, []string{"FeatureX", "FeatureY", "FeatureZ"})
-			// then
-			expectedData := []*app.Feature{}
-			assert.Equal(t, expectedData, featuresList.Data)
-		})
-
-		t.Run("no user provided only released features matches", func(t *testing.T) {
-			// when
-			_, featuresList := test.ListFeaturesOK(t, context.Background(), svc, ctrl, nil, []string{releasedFeature.Name, disabledFeature.Name, multiStrategiesFeature.Name})
-			// then
-			releasedLevel := featuretoggles.ReleasedLevel
-			betaLevel := featuretoggles.BetaLevel
-			expectedData := []*app.Feature{
-				{
-					ID:   releasedFeature.Name,
-					Type: "features",
-					Attributes: &app.FeatureAttributes{
-						Description:     releasedFeature.Description,
-						Enabled:         true,
-						UserEnabled:     true,
-						EnablementLevel: &releasedLevel,
-					},
-				},
-				{
-					ID:   disabledFeature.Name,
-					Type: "features",
-					Attributes: &app.FeatureAttributes{
-						Description:     disabledFeature.Description,
-						Enabled:         false,
-						UserEnabled:     false,
-						EnablementLevel: nil,
-					},
-				},
-				{
-					ID:   multiStrategiesFeature.Name,
-					Type: "features",
-					Attributes: &app.FeatureAttributes{
-						Description:     multiStrategiesFeature.Description,
-						Enabled:         true,
-						UserEnabled:     false,
-						EnablementLevel: &betaLevel,
-					},
-				},
-			}
-			assert.Equal(t, expectedData, featuresList.Data)
-		})
 	})
 
 	t.Run("list by pattern", func(t *testing.T) {
@@ -574,14 +514,14 @@ func TestListFeatures(t *testing.T) {
 			// when
 			ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
 			require.NoError(t, err)
-			_, featuresList := test.ListFeaturesOK(t, ctx, svc, ctrl, &pattern, nil)
+			_, featuresList := test.ListFeaturesOK(t, ctx, svc, ctrl, &pattern, nil, nil)
 			// then
 			experimentalLevel := featuretoggles.BetaLevel
-			expectedData := []*app.Feature{
+			expectedData := []*app.UserFeature{
 				{
 					ID:   disabledFeature.Name,
 					Type: "features",
-					Attributes: &app.FeatureAttributes{
+					Attributes: &app.UserFeatureAttributes{
 						Description:     disabledFeature.Description,
 						Enabled:         false,
 						UserEnabled:     false,
@@ -591,7 +531,7 @@ func TestListFeatures(t *testing.T) {
 				{
 					ID:   singleStrategyFeature.Name,
 					Type: "features",
-					Attributes: &app.FeatureAttributes{
+					Attributes: &app.UserFeatureAttributes{
 						Description:     singleStrategyFeature.Description,
 						Enabled:         true,
 						UserEnabled:     false,
@@ -601,7 +541,7 @@ func TestListFeatures(t *testing.T) {
 				{
 					ID:   multiStrategiesFeature.Name,
 					Type: "features",
-					Attributes: &app.FeatureAttributes{
+					Attributes: &app.UserFeatureAttributes{
 						Description:     multiStrategiesFeature.Description,
 						Enabled:         true,
 						UserEnabled:     true,
@@ -611,7 +551,7 @@ func TestListFeatures(t *testing.T) {
 				{
 					ID:   fooGroupFeature.Name,
 					Type: "features",
-					Attributes: &app.FeatureAttributes{
+					Attributes: &app.UserFeatureAttributes{
 						Description:     fooGroupFeature.Description,
 						Enabled:         false,
 						UserEnabled:     false,
@@ -620,6 +560,28 @@ func TestListFeatures(t *testing.T) {
 				},
 			}
 			assert.Equal(t, expectedData, featuresList.Data)
+		})
+
+		t.Run("no change", func(t *testing.T) {
+			// given
+			ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
+			require.NoError(t, err)
+			res, _ := test.ListFeaturesOK(t, ctx, svc, ctrl, &pattern, nil, nil)
+			require.NotEmpty(t, res.Header()[app.ETag])
+			etag := res.Header()[app.ETag][0]
+			// when/then
+			test.ListFeaturesNotModified(t, ctx, svc, ctrl, &pattern, nil, &etag)
+		})
+
+		t.Run("expired ETag", func(t *testing.T) {
+			// given
+			ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
+			require.NoError(t, err)
+			etag := "foo"
+			// when
+			_, features := test.ListFeaturesOK(t, ctx, svc, ctrl, &pattern, nil, &etag)
+			//then
+			assert.NotEmpty(t, features)
 		})
 
 		t.Run("no feature found", func(t *testing.T) {
@@ -627,112 +589,12 @@ func TestListFeatures(t *testing.T) {
 			ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
 			require.NoError(t, err)
 			pattern := "unknown"
-			_, featuresList := test.ListFeaturesOK(t, ctx, svc, ctrl, &pattern, nil)
+			_, featuresList := test.ListFeaturesOK(t, ctx, svc, ctrl, &pattern, nil, nil)
 			// then
-			expectedData := []*app.Feature{}
+			expectedData := []*app.UserFeature{}
 			assert.Equal(t, expectedData, featuresList.Data)
 		})
 
-		t.Run("no user provided", func(t *testing.T) {
-			// when
-			_, featuresList := test.ListFeaturesOK(t, context.Background(), svc, ctrl, &pattern, nil)
-			// then
-			// then
-			betaLevel := featuretoggles.BetaLevel
-			expectedData := []*app.Feature{
-				{
-					ID:   disabledFeature.Name,
-					Type: "features",
-					Attributes: &app.FeatureAttributes{
-						Description:     disabledFeature.Description,
-						Enabled:         false,
-						UserEnabled:     false,
-						EnablementLevel: nil,
-					},
-				},
-				{
-					ID:   singleStrategyFeature.Name,
-					Type: "features",
-					Attributes: &app.FeatureAttributes{
-						Description:     singleStrategyFeature.Description,
-						Enabled:         true,
-						UserEnabled:     false,
-						EnablementLevel: nil,
-					},
-				},
-				{
-					ID:   multiStrategiesFeature.Name,
-					Type: "features",
-					Attributes: &app.FeatureAttributes{
-						Description:     multiStrategiesFeature.Description,
-						Enabled:         true,
-						UserEnabled:     false,
-						EnablementLevel: &betaLevel,
-					},
-				},
-				{
-					ID:   fooGroupFeature.Name,
-					Type: "features",
-					Attributes: &app.FeatureAttributes{
-						Description:     fooGroupFeature.Description,
-						Enabled:         false,
-						UserEnabled:     false,
-						EnablementLevel: nil,
-					},
-				},
-			}
-			assert.Equal(t, expectedData, featuresList.Data)
-		})
-
-		t.Run("no user provided only released features matches", func(t *testing.T) {
-			// when
-			_, featuresList := test.ListFeaturesOK(t, context.Background(), svc, ctrl, &pattern, nil)
-			// then
-			betaLevel := featuretoggles.BetaLevel
-			expectedData := []*app.Feature{
-				{
-					ID:   disabledFeature.Name,
-					Type: "features",
-					Attributes: &app.FeatureAttributes{
-						Description:     disabledFeature.Description,
-						Enabled:         false,
-						UserEnabled:     false,
-						EnablementLevel: nil,
-					},
-				},
-				{
-					ID:   singleStrategyFeature.Name,
-					Type: "features",
-					Attributes: &app.FeatureAttributes{
-						Description:     singleStrategyFeature.Description,
-						Enabled:         true,
-						UserEnabled:     false,
-						EnablementLevel: nil,
-					},
-				},
-				{
-					ID:   multiStrategiesFeature.Name,
-					Type: "features",
-					Attributes: &app.FeatureAttributes{
-						Description:     multiStrategiesFeature.Description,
-						Enabled:         true,
-						UserEnabled:     false,
-						EnablementLevel: &betaLevel,
-					},
-				},
-				{
-					ID:   fooGroupFeature.Name,
-					Type: "features",
-					Attributes: &app.FeatureAttributes{
-						Description:     fooGroupFeature.Description,
-						Enabled:         false,
-						UserEnabled:     false,
-						EnablementLevel: nil,
-					},
-				},
-			}
-			assert.Equal(t, expectedData, featuresList.Data)
-		})
 	})
 
 	t.Run("invalid", func(t *testing.T) {
@@ -742,7 +604,7 @@ func TestListFeatures(t *testing.T) {
 			ctx, err := createValidContext("../test/private_key2.pem", "user_beta_level", time.Now().Add(1*time.Hour))
 			require.NoError(t, err)
 			// when/then
-			test.ListFeaturesUnauthorized(t, ctx, svc, ctrl, nil, []string{"FeatureX", "FeatureY", "FeatureZ"})
+			test.ListFeaturesUnauthorized(t, ctx, svc, ctrl, nil, []string{"FeatureX", "FeatureY", "FeatureZ"}, nil)
 		})
 
 		t.Run("expired token", func(t *testing.T) {
@@ -750,7 +612,17 @@ func TestListFeatures(t *testing.T) {
 			ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(-1*time.Hour))
 			require.NoError(t, err)
 			// when/then
-			test.ListFeaturesUnauthorized(t, ctx, svc, ctrl, nil, []string{"FeatureX", "FeatureY", "FeatureZ"})
+			test.ListFeaturesUnauthorized(t, ctx, svc, ctrl, nil, []string{"FeatureX", "FeatureY", "FeatureZ"}, nil)
+		})
+
+		t.Run("missing query param", func(t *testing.T) {
+			// given
+			ctx, err := createValidContext("../test/private_key.pem", "user_beta_level", time.Now().Add(1*time.Hour))
+			require.NoError(t, err)
+			// when
+			_, result := test.ListFeaturesOK(t, ctx, svc, ctrl, nil, nil, nil)
+			// then
+			require.Empty(t, result.Data)
 		})
 	})
 

--- a/design/api.go
+++ b/design/api.go
@@ -32,6 +32,12 @@ var _ = a.API("feature", func() {
 		a.Attribute("meta", a.HashOf(d.String, d.Any))
 	})
 
+	a.Trait("conditional", func() {
+		a.Headers(func() {
+			a.Header("If-None-Match", d.String)
+		})
+	})
+
 	a.Trait("jsonapi-media-type", func() {
 		a.ContentType("application/vnd.api+json")
 	})

--- a/design/features.go
+++ b/design/features.go
@@ -5,19 +5,19 @@ import (
 	a "github.com/goadesign/goa/design/apidsl"
 )
 
-var featureSingle = JSONSingle(
-	"Feature", "Holds a single feature",
-	feature,
+var userFeatureSingle = JSONSingle(
+	"UserFeature", "Holds a single user feature",
+	userFeature,
 	nil)
 
-var featureList = JSONList(
-	"Feature", "Holds the list of features",
-	feature,
+var userFeatureList = JSONList(
+	"UserFeature", "Holds the list of user features",
+	userFeature,
 	nil,
 	nil)
 
-var feature = a.Type("Feature", func() {
-	a.Description(`JSONAPI for the feature object. See also http://jsonapi.org/format/#document-resource-object`)
+var userFeature = a.Type("UserFeature", func() {
+	a.Description(`JSONAPI for the user feature object. See also http://jsonapi.org/format/#document-resource-object`)
 	a.Attribute("id", d.String, "Id of feature", func() {
 		a.Example("Feature name")
 	})
@@ -25,11 +25,11 @@ var feature = a.Type("Feature", func() {
 		a.Example("features")
 	})
 
-	a.Attribute("attributes", featureAttributes)
+	a.Attribute("attributes", userFeatureAttributes)
 	a.Required("id", "type", "attributes")
 })
 
-var featureAttributes = a.Type("FeatureAttributes", func() {
+var userFeatureAttributes = a.Type("UserFeatureAttributes", func() {
 	a.Description(`JSONAPI store for all the "attributes" of a Feature. See also see http://jsonapi.org/format/#document-resource-object-attributes`)
 	a.Attribute("description", d.String, "The description of the feature", func() {
 		a.Example("Description of the feature")
@@ -57,7 +57,9 @@ var _ = a.Resource("features", func() {
 			a.Param("featureName", d.String, "featureName")
 		})
 		a.Description("Show feature details.")
-		a.Response(d.OK, featureSingle)
+		a.UseTrait("conditional")
+		a.Response(d.OK, userFeatureSingle)
+		a.Response(d.NotModified)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
@@ -72,7 +74,9 @@ var _ = a.Resource("features", func() {
 			a.Param("group", d.String, "group")
 		})
 		a.Description("Show a list of features by their names.")
-		a.Response(d.OK, featureList)
+		a.UseTrait("conditional")
+		a.Response(d.OK, userFeatureList)
+		a.Response(d.NotModified)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)

--- a/featuretoggles/feature.go
+++ b/featuretoggles/feature.go
@@ -1,0 +1,18 @@
+package featuretoggles
+
+// UserFeature a feature with the user enablement
+type UserFeature struct {
+	Name            string
+	Description     string
+	Enabled         bool
+	EnablementLevel string
+	UserEnabled     bool
+}
+
+// GetETagData returns the field values to use to generate the ETag
+func (f UserFeature) GetETagData() []interface{} {
+	return []interface{}{f.Name, f.Enabled, f.EnablementLevel, f.UserEnabled}
+}
+
+// ZeroUserFeature to check if a feature is empty
+var ZeroUserFeature UserFeature

--- a/goasupport/conditional_request/generator.go
+++ b/goasupport/conditional_request/generator.go
@@ -1,0 +1,422 @@
+package conditionalrequest
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"strings"
+
+	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/goagen/codegen"
+)
+
+// Generate adds method to support conditional queries
+func Generate() ([]string, error) {
+	var (
+		ver    string
+		outDir string
+	)
+	set := flag.NewFlagSet("app", flag.PanicOnError)
+	set.String("design", "", "") // Consume design argument so Parse doesn't complain
+	set.StringVar(&ver, "version", "", "")
+	set.StringVar(&outDir, "out", "", "")
+	set.Parse(os.Args[2:])
+
+	// First check compatibility
+	if err := codegen.CheckVersion(ver); err != nil {
+		return nil, err
+	}
+
+	return WriteNames(design.Design, outDir)
+}
+
+// RequestContext holds a single goa Request Context object
+type RequestContext struct {
+	Name   string
+	Entity Entity
+}
+
+// RequestHeader holds a single HTTP Header as defined in the design for a Request Context
+type RequestHeader struct {
+	Name   string
+	Header string
+	Type   string
+}
+
+// Entity holds a single goa Response entity object that can be used in multiple responses.
+type Entity struct {
+	AppTypeName    string
+	DomainTypeName string
+	IsSingle       bool
+	IsList         bool
+}
+
+func contains(entities []Entity, entity Entity) bool {
+	for _, e := range entities {
+		if e.AppTypeName == entity.AppTypeName {
+			return true
+		}
+	}
+	return false
+
+}
+
+// aliases for the domain model packages, to avoid conflict with structure names generated in the `app` package
+var packageAliases map[string]string
+
+// map of domain structure names and their corresponding aliased package (unknown at the design level)
+var structPackages map[string]string
+
+var ignoredStructs []string
+
+func init() {
+	structPackages = make(map[string]string)
+	structPackages["UserFeature"] = "featuretoggles"
+}
+
+// WriteNames creates the names.txt file.
+func WriteNames(api *design.APIDefinition, outDir string) ([]string, error) {
+	// Now iterate through the resources to gather their names
+	var contexts []RequestContext
+	var entities []Entity
+
+	api.IterateResources(func(res *design.ResourceDefinition) error {
+		res.IterateActions(func(act *design.ActionDefinition) error {
+			name := fmt.Sprintf("%v%vContext", codegen.Goify(act.Name, true), codegen.Goify(res.Name, true))
+			// look-up headers for conditional request support
+			if act.Headers != nil {
+				// look-up headers and entity types in responses
+				if act.Responses != nil {
+					for _, response := range act.Responses {
+						if response.Name == design.OK && response.Type != nil {
+							if mt, ok := response.Type.(*design.MediaTypeDefinition); ok {
+								var entity *Entity
+								// lookup conditional request/response headers
+								for header := range response.Headers.Type.ToObject() {
+									if header == "ETag" {
+										// assume that a "list" entities have their name ending with "List"
+										// and "single" entities have their name ending with "Single"
+										isList := strings.HasSuffix(mt.TypeName, "List")
+										isArray := strings.HasSuffix(mt.TypeName, "Array")
+										var domainTypeName string
+										if isList {
+											domainTypeName = strings.TrimSuffix(mt.TypeName, "List")
+										} else if isArray {
+											domainTypeName = strings.TrimSuffix(mt.TypeName, "Array")
+										} else {
+											domainTypeName = strings.TrimSuffix(mt.TypeName, "Single")
+										}
+										// prepend the package
+										domainTypeName = fmt.Sprintf("%s.%s", structPackages[domainTypeName], domainTypeName)
+										entity = &Entity{
+											AppTypeName:    mt.TypeName,
+											DomainTypeName: domainTypeName,
+											IsList:         isList || isArray,
+											IsSingle:       !(isList || isArray),
+										}
+										break
+									}
+								}
+								// skip if no response header was found
+								if entity != nil {
+									fmt.Printf("Response context: %s -> entity: %v\n", name, entity)
+									// for k, v := range m.ToObject() {
+									// 	fmt.Printf("%s -> %v\n", k, v)
+									// }
+									ctx := RequestContext{Name: name, Entity: *entity}
+									contexts = append(contexts, ctx)
+									if !contains(entities, *entity) {
+										entities = append(entities, *entity)
+									}
+
+								}
+							}
+						}
+					}
+				}
+			}
+			return nil
+		})
+		return nil
+	})
+
+	ctxFile := filepath.Join(outDir, "conditional_requests.go")
+	ctxWr, err := codegen.SourceFileFor(ctxFile)
+	if err != nil {
+		panic(err) // bug
+	}
+	title := fmt.Sprintf("%s: Conditional Requests methods - See goasupport/conditional_request/generator.go", api.Context())
+	imports := []*codegen.ImportSpec{
+		codegen.SimpleImport("bytes"),
+		codegen.SimpleImport("crypto/md5"),
+		codegen.SimpleImport("encoding/base64"),
+		codegen.SimpleImport("strconv"),
+		codegen.SimpleImport("net/http"),
+		codegen.SimpleImport("time"),
+		codegen.SimpleImport("fmt"),
+		codegen.SimpleImport("reflect"),
+		codegen.SimpleImport("github.com/fabric8-services/fabric8-toggles-service/configuration"),
+		codegen.SimpleImport("github.com/fabric8-services/fabric8-auth/log"),
+		codegen.SimpleImport("github.com/fabric8-services/fabric8-toggles-service/featuretoggles"),
+		codegen.NewImport("uuid", "github.com/satori/go.uuid"),
+	}
+	// add imports for domain packages
+	for alias, pkg := range packageAliases {
+		imports = append(imports, codegen.NewImport(alias, pkg))
+	}
+	ctxWr.WriteHeader(title, "app", imports)
+	if err := ctxWr.ExecuteTemplate("constants", constants, nil, nil); err != nil {
+		return nil, err
+	}
+	if err := ctxWr.ExecuteTemplate("cacheControlConfig", cacheControlConfig, nil, nil); err != nil {
+		return nil, err
+	}
+	if err := ctxWr.ExecuteTemplate("conditionalRequestContext", conditionalRequestContext, nil, nil); err != nil {
+		return nil, err
+	}
+	if err := ctxWr.ExecuteTemplate("conditionalResponseEntity", conditionalResponseEntity, nil, nil); err != nil {
+		return nil, err
+	}
+	if err := ctxWr.ExecuteTemplate("doConditionals", doConditionals, nil, nil); err != nil {
+		return nil, err
+	}
+	if err := ctxWr.ExecuteTemplate("generateETag", generateETag, nil, nil); err != nil {
+		return nil, err
+	}
+	if err := ctxWr.ExecuteTemplate("matchesETag", matchesETag, nil, nil); err != nil {
+		return nil, err
+	}
+	for _, ctx := range contexts {
+		if err := ctxWr.ExecuteTemplate("conditional", conditional, nil, ctx); err != nil {
+			return nil, err
+		}
+		if err := ctxWr.ExecuteTemplate("getIfNoneMatch", getIfNoneMatch, nil, ctx); err != nil {
+			return nil, err
+		}
+		if err := ctxWr.ExecuteTemplate("setETag", setETag, nil, ctx); err != nil {
+			return nil, err
+		}
+		if err := ctxWr.ExecuteTemplate("setCacheControl", setCacheControl, nil, ctx); err != nil {
+			return nil, err
+		}
+	}
+	err = ctxWr.FormatCode()
+	if err != nil {
+		return nil, err
+	}
+	return []string{ctxFile}, nil
+}
+
+const (
+	constants = `
+	const (
+	// IfNoneMatch the "If-None-Match" HTTP request header name
+	IfNoneMatch = "If-None-Match"
+	// ETag the "ETag" HTTP response header name
+	// should be ETag but GOA will convert it to "Etag" when setting the header.
+	// Plus, RFC 2616 specifies that header names are case insensitive:
+	// https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
+	ETag = "Etag"
+	// CacheControl the "Cache-Control" HTTP response header name
+	CacheControl = "Cache-Control"
+	// MaxAge the "max-age" HTTP response header value
+	MaxAge = "max-age"
+)`
+
+	conditionalRequestContext = `
+// ConditionalRequestContext interface with methods for the contexts
+type ConditionalRequestContext interface {
+	NotModified() error
+	getIfNoneMatch() *string
+	setETag(string)
+	setCacheControl(string)
+}`
+
+	conditionalResponseEntity = `
+	// ConditionalRequestEntity interface with methods for the response entities
+type ConditionalRequestEntity interface {
+	// returns the values to use to generate the ETag
+	GetETagData() []interface{}
+}`
+
+	cacheControlConfig = `
+   type CacheControlConfig func() string
+   `
+	doConditionals = `
+func doConditionalRequest(ctx ConditionalRequestContext, entity ConditionalRequestEntity, cacheControlConfig CacheControlConfig, nonConditionalCallback func() error) error {
+	eTag := GenerateEntityTag(entity)
+	cacheControl := cacheControlConfig()
+	ctx.setETag(eTag)
+	ctx.setCacheControl(cacheControl)
+	// check the 'If-None-Match' header first.
+	found, match := matchesETag(ctx, eTag)
+	if found && match {
+		return ctx.NotModified()
+	}
+	// call the 'nonConditionalCallback' if the entity was modified since the client's last call
+	return nonConditionalCallback()
+}
+
+func doConditionalEntities(ctx ConditionalRequestContext, entities []ConditionalRequestEntity, cacheControlConfig CacheControlConfig, nonConditionalCallback func() error) error {
+	var eTag string
+	if len(entities) > 0 {
+		eTag = GenerateEntitiesTag(entities)
+	} else {
+		eTag = GenerateEmptyTag()
+	}
+	ctx.setETag(eTag)
+	cacheControl := cacheControlConfig()
+	ctx.setCacheControl(cacheControl)
+	// check the 'If-None-Match' header first.
+	found, match := matchesETag(ctx, eTag)
+	if found && match {
+		return ctx.NotModified()
+	}
+	// call the 'nonConditionalCallback' if the entity was modified since the client's last call
+	return nonConditionalCallback()
+}`
+
+	conditional = `
+{{ $resp := . }}
+{{ $entity := $resp.Entity }}
+{{ if $entity.IsSingle }}
+// ConditionalRequest checks if the entity to return changed since the client's last call and returns a "304 Not Modified" response
+// or calls the 'nonConditionalCallback' function to carry on.
+func (ctx *{{$resp.Name}}) ConditionalRequest(entity {{$entity.DomainTypeName}}, cacheControlConfig CacheControlConfig, nonConditionalCallback func() error) error {
+	return doConditionalRequest(ctx, entity, cacheControlConfig, nonConditionalCallback)
+}
+
+{{ end }}
+{{ if $entity.IsList }}
+// ConditionalEntities checks if the entities to return changed since the client's last call and returns a "304 Not Modified" response
+// or calls the 'nonConditionalCallback' function to carry on.
+func (ctx *{{$resp.Name}}) ConditionalEntities(entities []{{$entity.DomainTypeName}}, cacheControlConfig CacheControlConfig, nonConditionalCallback func() error) error {
+	conditionalEntities := make([]ConditionalRequestEntity, len(entities))
+	for i, entity := range entities {
+		conditionalEntities[i] = entity
+	}
+	return doConditionalEntities(ctx, conditionalEntities, cacheControlConfig, nonConditionalCallback)
+}
+
+{{ end }}`
+	generateETag = `
+// GenerateEmptyTag generates the value to return in the "ETag" HTTP response header for the an empty list of entities
+// The ETag is the base64-encoded value of the md5 hash of the buffer content
+func GenerateEmptyTag() string {
+	var buffer bytes.Buffer
+	buffer.WriteString("empty")
+	etagData := md5.Sum(buffer.Bytes())
+	etag := base64.StdEncoding.EncodeToString(etagData[:])
+	return etag
+}
+// GenerateEntityTag generates the value to return in the "ETag" HTTP response header for the given entity
+// The ETag is the base64-encoded value of the md5 hash of the buffer content
+func GenerateEntityTag(entity ConditionalRequestEntity) string {
+	var buffer bytes.Buffer
+	buffer.WriteString(generateETagValue(entity.GetETagData()))
+	etagData := md5.Sum(buffer.Bytes())
+	etag := base64.StdEncoding.EncodeToString(etagData[:])
+	return etag
+}
+
+// GenerateEntitiesTag generates the value to return in the "ETag" HTTP response header for the given list of entities
+// The ETag is the base64-encoded value of the md5 hash of the buffer content
+func GenerateEntitiesTag(entities []ConditionalRequestEntity) string {
+	var buffer bytes.Buffer
+	for i, entity := range entities {
+		buffer.WriteString(generateETagValue(entity.GetETagData()))
+		if i < len(entities)-1 {
+			buffer.WriteString("\n")
+		}
+	}
+	etagData := md5.Sum(buffer.Bytes())
+	etag := base64.StdEncoding.EncodeToString(etagData[:])
+	return etag
+}
+func generateETagValue(data []interface{}, options ...interface{}) string {
+	var buffer bytes.Buffer
+	for i, d := range data {
+		switch d := d.(type) {
+		case []interface{}:
+			// if the entry in the 'data' array is itself an array,
+			// then we recursively call the 'generateETagValue' function with this array entry.
+			buffer.WriteString(generateETagValue(d))
+		case string:
+			buffer.WriteString(d)
+		case *string:
+			if d != nil {
+				buffer.WriteString(*d)
+			}
+		case time.Time:
+			buffer.WriteString(d.UTC().String())
+		case *time.Time:
+			if d != nil {
+				buffer.WriteString(d.UTC().String())
+			}
+		case int:
+			buffer.WriteString(strconv.Itoa(d))
+		case *int:
+			if d != nil {
+				buffer.WriteString(strconv.Itoa(*d))
+			}
+		case uuid.UUID:
+			buffer.WriteString(d.String())
+		case *uuid.UUID:
+			if d != nil {
+				buffer.WriteString(d.String())
+			}
+		default:
+			log.Logger().Errorln(fmt.Sprintf("Unexpected Etag fragment format: %v", reflect.TypeOf(d)))
+		}
+		if i < len(data)-1 {
+			buffer.WriteString("|")
+		}
+	}
+	return buffer.String()
+}`
+
+	setETag = `
+{{ $resp := . }}
+// setETag sets the 'ETag' header
+func (ctx *{{$resp.Name}}) setETag(value string) {
+	ctx.ResponseData.Header().Set(ETag, value)
+}`
+
+	getIfNoneMatch = `
+{{ $resp := . }}
+// getIfNoneMatch sets the 'If-None-Match' header
+func (ctx *{{$resp.Name}}) getIfNoneMatch() *string {
+	return ctx.IfNoneMatch
+}`
+
+	matchesETag = `
+// matchesETag compares the given 'etag' argument matches with the context's 'IfNoneMatch' value.
+// Returns 'true, true' if the 'If-None-Match' field was found and matched given 'etag' argument
+// Returns 'true, false' if the 'If-None-Match' field was found but did not match given 'etag' argument
+// Returns 'false, false' if the 'If-None-Match' field was not found
+func matchesETag(ctx ConditionalRequestContext, etag string) (bool, bool) {
+	if ctx.getIfNoneMatch() != nil {
+		if *ctx.getIfNoneMatch() == etag {
+			// 'If-None-Match' field was found and matched the given 'etag' argument
+			return true, true
+		}
+		// 'If-None-Match' field was found and but did not match the given 'etag' argument
+		return true, false
+	}
+	// 'If-None-Match' field was not found
+	return false, false
+}`
+	setCacheControl = `
+{{ $resp := . }}
+// SetCacheControl sets the 'Cache-Control' header
+func (ctx *{{$resp.Name}}) setCacheControl(value string) {
+	ctx.ResponseData.Header().Set(CacheControl, value)
+}`
+	toHTTPTime = `
+// ToHTTPTime utility function to convert a 'time.Time' into a valid HTTP date
+func ToHTTPTime(value time.Time) string {
+	return value.UTC().Format(http.TimeFormat)
+}`
+)


### PR DESCRIPTION
Generate conditional support at the goa level
Refactor code to introduce a new `featuretoggles.USerFeature` type
that contains the feature data along with the user enablement
The controller only needs to convert to the `app.UserFeature[Single|List]`
type and respond to the client, the `IsEnabled` is done during the initial
call to the `GetFeature()`/`GetFeaturesByName()`/`GetFeaturesByPattern()`.

Fixes openshiftio/openshift.io#3218

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>