### PR TITLE
Invalid feature enablement update after user changes settings (OSIO#3308)

### DIFF
--- a/featuretoggles/user_feature.go
+++ b/featuretoggles/user_feature.go
@@ -11,7 +11,7 @@ type UserFeature struct {
 
 // GetETagData returns the field values to use to generate the ETag
 func (f UserFeature) GetETagData() []interface{} {
-	return []interface{}{f.Name, f.Enabled, f.EnablementLevel, f.UserEnabled}
+	return []interface{}{f.Name, f.Description, f.Enabled, f.EnablementLevel, f.UserEnabled}
 }
 
 // ZeroUserFeature to check if a feature is empty

--- a/featuretoggles/user_feature_test.go
+++ b/featuretoggles/user_feature_test.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/fabric8-services/fabric8-toggles-service/app"
 	"github.com/fabric8-services/fabric8-toggles-service/featuretoggles"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,5 +22,81 @@ func TestSortUserFeartures(t *testing.T) {
 	require.Len(t, features, 2)
 	assert.Equal(t, "bar", features[0].Name)
 	assert.Equal(t, "foo", features[1].Name)
+}
 
+func TestComputeUserFeatureEtag(t *testing.T) {
+	// given
+	feature := featuretoggles.UserFeature{
+		Name:            "foo",
+		Description:     "foo",
+		UserEnabled:     false,
+		Enabled:         false,
+		EnablementLevel: featuretoggles.BetaLevel,
+	}
+
+	t.Run("change name", func(t *testing.T) {
+		// given
+		feature2 := duplicate(feature)
+		feature2.Name = "bar"
+		// when
+		etag := app.GenerateEntityTag(feature)
+		etag2 := app.GenerateEntityTag(feature2)
+		// then
+		assert.NotEqual(t, etag2, etag)
+	})
+
+	t.Run("change description", func(t *testing.T) {
+		// given
+		feature2 := duplicate(feature)
+		feature2.Description = "bar"
+		// when
+		etag := app.GenerateEntityTag(feature)
+		etag2 := app.GenerateEntityTag(feature2)
+		// then
+		assert.NotEqual(t, etag2, etag)
+	})
+
+	t.Run("change enabled", func(t *testing.T) {
+		// given
+		feature2 := duplicate(feature)
+		feature2.Enabled = true
+		// when
+		etag := app.GenerateEntityTag(feature)
+		etag2 := app.GenerateEntityTag(feature2)
+		// then
+		assert.NotEqual(t, etag2, etag)
+	})
+
+	t.Run("change enablement level", func(t *testing.T) {
+		// given
+		feature2 := duplicate(feature)
+		feature2.EnablementLevel = featuretoggles.InternalLevel
+		// when
+		etag := app.GenerateEntityTag(feature)
+		etag2 := app.GenerateEntityTag(feature2)
+		// then
+		assert.NotEqual(t, etag2, etag)
+	})
+
+	t.Run("change user-enabled", func(t *testing.T) {
+		// given
+		feature2 := duplicate(feature)
+		feature2.UserEnabled = true
+		// when
+		etag := app.GenerateEntityTag(feature)
+		etag2 := app.GenerateEntityTag(feature2)
+		// then
+		assert.NotEqual(t, etag2, etag)
+	})
+
+}
+
+func duplicate(f featuretoggles.UserFeature) featuretoggles.UserFeature {
+	return featuretoggles.UserFeature{
+		Name:            f.Name,
+		Description:     f.Description,
+		Enabled:         f.Enabled,
+		EnablementLevel: f.EnablementLevel,
+		UserEnabled:     f.UserEnabled,
+	}
 }

--- a/goasupport/conditional_request/generator.go
+++ b/goasupport/conditional_request/generator.go
@@ -367,6 +367,8 @@ func generateETagValue(data []interface{}, options ...interface{}) string {
 			if d != nil {
 				buffer.WriteString(d.String())
 			}
+		case bool:
+			buffer.WriteString(strconv.FormatBool(d))
 		default:
 			log.Logger().Errorln(fmt.Sprintf("Unexpected Etag fragment format: %v", reflect.TypeOf(d)))
 		}


### PR DESCRIPTION
Take into account the `bool` fields of the `featuretoggles.UserFeature` structure
Also, include the feature description in the ETag computation

Fixes openshiftio/openshift.io#3308

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>